### PR TITLE
Real Fix for QJSValue Segmentation Fault

### DIFF
--- a/bosswave.cpp
+++ b/bosswave.cpp
@@ -52,12 +52,12 @@ private:
     const char* msg;
 };
 
-Res<QString> BW::_nop_res_status;
+Res<QString> BW::_nop_res_status([](QString) {});
 
 BW::BW(QObject *parent):
     QObject(parent)
 {
-    _nop_res_status = [](QString) {};
+    Q_ASSERT(this->thread() == QCoreApplication::instance()->thread());
     m_agent = NULL;
 }
 

--- a/bosswave.h
+++ b/bosswave.h
@@ -1717,8 +1717,9 @@ class BWView : public QObject
     Q_PROPERTY(QStringList services READ services NOTIFY servicesChanged)
 
 public:
-    BWView(BW* parent) : QObject(parent), bw(parent) {
-
+    BWView(BW* parent) : QObject(parent), bw(parent)
+    {
+        Q_ASSERT(this->thread() == QCoreApplication::instance()->thread());
     }
     const QStringList& services();
     const QVariantList& interfaces();

--- a/bosswave.h
+++ b/bosswave.h
@@ -1369,7 +1369,7 @@ private:
     AgentConnection *m_agent;
     QString m_vk;
 
-    template <typename ...Tz> Res<Tz...> ERes(const QJSValue& callback)
+    template <typename ...Tz> Res<Tz...> ERes(QJSValue callback)
     {
         return Res<Tz...>(jsengine, callback);
     }

--- a/utils.h
+++ b/utils.h
@@ -9,6 +9,18 @@
 
 using std::function;
 
+template<typename... Tz> void invokeOnThread(QThread* t, function<void (Tz...)> f, Tz... args)
+{
+    QTimer* timer = new QTimer();
+    timer->moveToThread(t);
+    timer->setSingleShot(true);
+    QObject::connect(timer, &QTimer::timeout, [=]{
+        f(args...);
+        timer->deleteLater();
+    });
+    QMetaObject::invokeMethod(timer, "start", Qt::QueuedConnection, Q_ARG(int, 0));
+}
+
 template <typename F, typename ...R> void convert(QJSValueList &l, F f, R... rest)
 {
     l.append(QJSValue(f));


### PR DESCRIPTION
@immesys: I think I've finally tracked down the bug that was causing WaveViewer to crash.

The reason is that a QJSValue should not be constructed or passed by value except in the GUI thread. I'm not sure why this is the case. My guess is that a QJSValue counts as a "reference" from the perspective of Javascript's garbage collector, and that the Javascript engine doesn't handle the case where an object may be created in a different thread.

Although the AgentConnection class makes sure to always invoke the callback in the thread specified as a parameter to the "transact" method, it internally passes this callback by value multiple times. The problem is that this callback often captures a "Res" representing the callback passed to the original function in the bosswave bindings. Thus, passing the callback by value implicitly copy-constructs a new Res, which may copy-construct a new QJSValue if the callback originated from Javascript.

This means that we need to enforce the additional constraint that the callback to transact is only passed by value on the GUI thread. Currently the constraint is violated at https://github.com/immesys/qtlibbw/blob/master/agentconnection.cpp#L371.

I understand that the doTransact method can't be called on the GUI thread because you don't want to block the entire GUI on socket operations. The solution I submitted in Pull Request #17 works because, by dynamically allocating the QJSValue, I make sure that the copy constructor of Res does not ever result in the copy constructor of QJSValue being called.

However, I am still concerned that a similar rule may apply to the QJSValue destructor. If the QJSValue destructor needs to be called from the GUI thread, then we're still in trouble, because the last reference to the callback is lost at https://github.com/immesys/qtlibbw/blob/master/agentconnection.cpp#L342, which executes in the AgentConnection's thread. To fix this problem, using a shared pointer isn't the way to go because I don't have control over the thread on which the shared object is deleted.

So the fix I implemented is to make sure that all operations with the "outstanding" hash table happen on the GUI thread. These should be very fast, so they won't impact user experience. It will make sure that all copying of QJSValues happens on the GUI thread, fixing the problems outlined above.

I also added some assertions to make sure that a Res is never copied outside of the GUI thread, since any Res could be a wrapper around a QJSValue.
